### PR TITLE
refactor(dialogs): Route dialogs to their own path

### DIFF
--- a/src/components/AppRouter.jsx
+++ b/src/components/AppRouter.jsx
@@ -6,44 +6,40 @@ import { GradesView } from './Views/GradesView'
 import { PresenceView } from './Views/PresenceView'
 import { HomeworksView } from './Views/HomeworksView'
 import { TimetableView } from './Views/TimetableView'
+import { TimetableModal } from './Dialogs/TimetableModal'
+import { GradeModal } from './Dialogs/GradesModal'
 
 const routes = [
   {
-    path: 'timetable',
+    path: '',
     element: <AppLayout />,
     children: [
       {
-        path: '',
-        element: <TimetableView />
-      }
-    ]
-  },
-  {
-    path: 'homeworks',
-    element: <AppLayout />,
-    children: [
+        path: 'timetable',
+        element: <TimetableView />,
+        children: [
+          {
+            path: 'course/:courseId',
+            element: <TimetableModal />
+          }
+        ]
+      },
       {
-        path: '',
+        path: 'homeworks',
         element: <HomeworksView />
-      }
-    ]
-  },
-  {
-    path: 'grades',
-    element: <AppLayout />,
-    children: [
+      },
       {
-        path: '',
-        element: <GradesView />
-      }
-    ]
-  },
-  {
-    path: 'presence',
-    element: <AppLayout />,
-    children: [
+        path: 'grades',
+        element: <GradesView />,
+        children: [
+          {
+            path: 'grade/:subjectId/:gradeId',
+            element: <GradeModal />
+          }
+        ]
+      },
       {
-        path: '',
+        path: 'presence',
         element: <PresenceView />
       }
     ]

--- a/src/components/Dialogs/GradesModal.jsx
+++ b/src/components/Dialogs/GradesModal.jsx
@@ -7,7 +7,7 @@ import {
   DialogCloseButton,
   useCozyDialog
 } from 'cozy-ui/transpiled/react/CozyDialogs'
-import Dialog, { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Divider from 'cozy-ui/transpiled/react/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import CalendarIcon from 'cozy-ui/transpiled/react/Icons/Calendar'
@@ -26,17 +26,6 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 export const GradeModal = ({ grade, subject, closeModalAction }) => {
-  const { isMobile } = useBreakpoints()
-  const { dialogProps, dialogTitleProps } = useCozyDialog({
-    size: 'medium',
-    classes: {
-      paper: 'my-class'
-    },
-    open,
-    onClose: closeModalAction,
-    disableEnforceFocus: true
-  })
-
   const { t } = useI18n()
 
   const valuesList = [
@@ -68,12 +57,12 @@ export const GradeModal = ({ grade, subject, closeModalAction }) => {
   ]
 
   return (
-    <Dialog {...dialogProps}>
-      {!isMobile && <DialogCloseButton onClick={closeModalAction} />}
-
-      <DialogTitle {...dialogTitleProps}>
-        {isMobile ? <DialogBackButton onClick={closeModalAction} /> : null}
-
+    <Dialog
+      open
+      onClose={() => closeModalAction()}
+      disableGutters
+      
+      title={
         <div style={{ display: 'flex', flexDirection: 'column', gap: '2px' }}>
           <MuiBreadcrumbs>
             <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
@@ -113,103 +102,105 @@ export const GradeModal = ({ grade, subject, closeModalAction }) => {
             </Typography>
           </div>
         </div>
-      </DialogTitle>
+      }
 
-      <Divider />
-
-      <List
-        subheader={<ListSubheader>{t('Grades.dialogContext')}</ListSubheader>}
-      >
-        <ListItem>
-          <ListItemIcon>
-            <Icon icon={CalendarIcon} />
-          </ListItemIcon>
-          <ListItemText
-            primary={t('Grades.date')}
-            secondary={new Date(grade.date).toLocaleDateString('fr-FR', {
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
-          />
-        </ListItem>
-        <Divider component="li" variant="inset" />
-        <ListItem>
-          <ListItemIcon>
-            <Icon icon={PercentIcon} />
-          </ListItemIcon>
-          <ListItemText
-            primary={t('Grades.values.coefficient.title')}
-            secondary={t('Grades.values.coefficient.description')}
-          />
-
-          <div
-            className="cozy-grade-chip"
-            style={{ display: 'flex', alignItems: 'flex-end' }}
+      content={
+        <div>
+          <List
+            subheader={<ListSubheader>{t('Grades.dialogContext')}</ListSubheader>}
           >
-            <Typography variant="body2" color="textSecondary">
-              x
-            </Typography>
-            <Typography
-              variant="body1"
-              color="textPrimary"
-              style={{ fontWeight: 'bold' }}
-            >
-              {parseFloat(grade.value.coef).toFixed(2)}
-            </Typography>
-          </div>
-        </ListItem>
-      </List>
+            <ListItem>
+              <ListItemIcon>
+                <Icon icon={CalendarIcon} />
+              </ListItemIcon>
+              <ListItemText
+                primary={t('Grades.date')}
+                secondary={new Date(grade.date).toLocaleDateString('fr-FR', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric'
+                })}
+              />
+            </ListItem>
+            <Divider component="li" variant="inset" />
+            <ListItem>
+              <ListItemIcon>
+                <Icon icon={PercentIcon} />
+              </ListItemIcon>
+              <ListItemText
+                primary={t('Grades.values.coefficient.title')}
+                secondary={t('Grades.values.coefficient.description')}
+              />
 
-      <List subheader={<ListSubheader>{t('Grades.valuesList')}</ListSubheader>}>
-        {valuesList.map(
-          (value, i) =>
-            value && (
-              <div key={i}>
-                <ListItem>
-                  <ListItemIcon>
-                    <Icon icon={value.icon} />
-                  </ListItemIcon>
-
-                  <ListItemText
-                    primary={
-                      <Typography
-                        variant="body1"
-                        style={{
-                          fontWeight: value.important ? 'bold' : 'normal'
-                        }}
-                      >
-                        {value.primary}
-                      </Typography>
-                    }
-                    secondary={value.secondary}
-                  />
-
-                  <div
-                    className="cozy-grade-chip"
-                    style={{ display: 'flex', alignItems: 'flex-end' }}
-                  >
-                    <Typography
-                      variant="body1"
-                      color="textPrimary"
-                      style={{
-                        fontWeight: value.important ? 'bold' : 'normal'
-                      }}
-                    >
-                      {parseFloat(value.value).toFixed(2)}
-                    </Typography>
-                    <Typography variant="body2" color="textSecondary">
-                      /{parseFloat(grade.value.outOf).toFixed(0)}
-                    </Typography>
-                  </div>
-                </ListItem>
-                {i !== valuesList.length - 1 && (
-                  <Divider component="li" variant="inset" />
-                )}
+              <div
+                className="cozy-grade-chip"
+                style={{ display: 'flex', alignItems: 'flex-end' }}
+              >
+                <Typography variant="body2" color="textSecondary">
+                  x
+                </Typography>
+                <Typography
+                  variant="body1"
+                  color="textPrimary"
+                  style={{ fontWeight: 'bold' }}
+                >
+                  {parseFloat(grade.value.coef).toFixed(2)}
+                </Typography>
               </div>
-            )
-        )}
-      </List>
-    </Dialog>
+            </ListItem>
+          </List>
+
+          <List subheader={<ListSubheader>{t('Grades.valuesList')}</ListSubheader>}>
+            {valuesList.map(
+              (value, i) =>
+                value && (
+                  <div key={i}>
+                    <ListItem>
+                      <ListItemIcon>
+                        <Icon icon={value.icon} />
+                      </ListItemIcon>
+
+                      <ListItemText
+                        primary={
+                          <Typography
+                            variant="body1"
+                            style={{
+                              fontWeight: value.important ? 'bold' : 'normal'
+                            }}
+                          >
+                            {value.primary}
+                          </Typography>
+                        }
+                        secondary={value.secondary}
+                      />
+
+                      <div
+                        className="cozy-grade-chip"
+                        style={{ display: 'flex', alignItems: 'flex-end' }}
+                      >
+                        <Typography
+                          variant="body1"
+                          color="textPrimary"
+                          style={{
+                            fontWeight: value.important ? 'bold' : 'normal'
+                          }}
+                        >
+                          {parseFloat(value.value).toFixed(2)}
+                        </Typography>
+                        <Typography variant="body2" color="textSecondary">
+                          /{parseFloat(grade.value.outOf).toFixed(0)}
+                        </Typography>
+                      </div>
+                    </ListItem>
+                    {i !== valuesList.length - 1 && (
+                      <Divider component="li" variant="inset" />
+                    )}
+                  </div>
+                )
+            )}
+          </List>
+        </div>
+      }
+    />
   )
 }

--- a/src/components/Dialogs/GradesModal.jsx
+++ b/src/components/Dialogs/GradesModal.jsx
@@ -24,9 +24,30 @@ import ListSubheader from 'cozy-ui/transpiled/react/ListSubheader'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useQuery } from 'cozy-client'
+import { buildGradeItemQuery } from 'src/queries'
 
-export const GradeModal = ({ grade, subject, closeModalAction }) => {
+export const GradeModal = () => {
   const { t } = useI18n()
+  const { subjectId, gradeId } = useParams()
+  const navigate = useNavigate()
+
+  console.log('subjectId', subjectId)
+  console.log('gradeId', gradeId)
+
+  const gradeItemQuery = buildGradeItemQuery(subjectId)
+  const { data: subjects, fetchStatus } = useQuery(
+    gradeItemQuery.definition,
+    gradeItemQuery.options
+  )
+
+  const subject = subjects ? subjects[0] : null;
+  const grade = subject && subject.series.find(grade => grade.id === gradeId);
+
+  if(!grade) {
+    return <div />;
+  }
 
   const valuesList = [
     {
@@ -59,7 +80,7 @@ export const GradeModal = ({ grade, subject, closeModalAction }) => {
   return (
     <Dialog
       open
-      onClose={() => closeModalAction()}
+      onClose={() => navigate(-1)}
       disableGutters
       
       title={

--- a/src/components/Dialogs/TimetableModal.jsx
+++ b/src/components/Dialogs/TimetableModal.jsx
@@ -1,10 +1,17 @@
 import React from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import { getSubjectName } from 'src/format/subjectName'
+import { buildTimetableItemQuery } from 'src/queries'
 
+import { useQuery } from 'cozy-client'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Divider from 'cozy-ui/transpiled/react/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
+import ClockIcon from 'cozy-ui/transpiled/react/Icons/Clock'
+import ClockOutlineIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
 import InfoIcon from 'cozy-ui/transpiled/react/Icons/Info'
+import LocationIcon from 'cozy-ui/transpiled/react/Icons/Location'
+import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 import List from 'cozy-ui/transpiled/react/List'
 import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemIcon from 'cozy-ui/transpiled/react/ListItemIcon'
@@ -13,76 +20,83 @@ import ListSubheader from 'cozy-ui/transpiled/react/ListSubheader'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
-import ClockIcon from 'cozy-ui/transpiled/react/Icons/Clock'
-import ClockOutlineIcon from 'cozy-ui/transpiled/react/Icons/ClockOutline'
-import LocationIcon from 'cozy-ui/transpiled/react/Icons/Location'
-import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 
-export const TimetableModal = ({ course, closeModalAction }) => {
-  const { isMobile } = useBreakpoints()
+export const TimetableModal = () => {
+  const { courseId } = useParams()
+  const navigate = useNavigate()
+
+  const timetableItemQuery = buildTimetableItemQuery(courseId)
+  const { data: courses, fetchStatus } = useQuery(
+    timetableItemQuery.definition,
+    timetableItemQuery.options
+  )
+
+  const course = courses ? courses[0] : null
 
   const { t } = useI18n()
 
-  const Time = [
-    {
-      title: t('Timetable.start'),
-      subtitle: new Date(course.start).toLocaleTimeString('default', {
-        hour: '2-digit',
-        minute: '2-digit'
-      }),
-      icon: ClockIcon
-    },
-    {
-      title: t('Timetable.end'),
-      subtitle: new Date(course.end).toLocaleTimeString('default', {
-        hour: '2-digit',
-        minute: '2-digit'
-      }),
-      icon: ClockOutlineIcon
-    }
-  ]
+  const Time = course
+    ? [
+        {
+          title: t('Timetable.start'),
+          subtitle: new Date(course.start).toLocaleTimeString('default', {
+            hour: '2-digit',
+            minute: '2-digit'
+          }),
+          icon: ClockIcon
+        },
+        {
+          title: t('Timetable.end'),
+          subtitle: new Date(course.end).toLocaleTimeString('default', {
+            hour: '2-digit',
+            minute: '2-digit'
+          }),
+          icon: ClockOutlineIcon
+        }
+      ]
+    : []
 
-  const Informations = [
-    {
-      title: t('Timetable.location'),
-      subtitle: course.location ?? 'Non défini',
-      icon: PeopleIcon
-    },
-    {
-      title: t('Timetable.teacher'),
-      subtitle: course.organizer ?? 'Non défini',
-      icon: LocationIcon
-    },
-    {
-      title: t('Timetable.status'),
-      subtitle:
-        (course.status ?? '') == 'CONFIRMED' ? 'Maintenu' : 'Non maintenu',
-      icon: InfoIcon
-    }
-  ]
+  const Informations = course
+    ? [
+        {
+          title: t('Timetable.location'),
+          subtitle: course.location ?? 'Non défini',
+          icon: PeopleIcon
+        },
+        {
+          title: t('Timetable.teacher'),
+          subtitle: course.organizer ?? 'Non défini',
+          icon: LocationIcon
+        },
+        {
+          title: t('Timetable.status'),
+          subtitle:
+            (course.status ?? '') == 'CONFIRMED' ? 'Maintenu' : 'Non maintenu',
+          icon: InfoIcon
+        }
+      ]
+    : []
 
   return (
     <Dialog
       open
-      onClose={() => closeModalAction()}
       disableGutters
-
+      onClose={() => navigate(-1)}
       title={
-          <div>
-            <Typography variant="h5">
-              {getSubjectName(course.subject).pretty}
-            </Typography>
-            <Typography variant="subtitle2" color="textSecondary">
-              {new Date(course.start).toLocaleDateString('default', {
-                weekday: 'long',
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric'
-              })}
-            </Typography>
-          </div>
+        <div>
+          <Typography variant="h5">
+            {getSubjectName(course?.subject ?? '').pretty ?? 'Non défini'}
+          </Typography>
+          <Typography variant="subtitle2" color="textSecondary">
+            {new Date(course?.start).toLocaleDateString('default', {
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
+            }) ?? 'Non défini'}
+          </Typography>
+        </div>
       }
-
       content={
         <div>
           <List>

--- a/src/components/Dialogs/TimetableModal.jsx
+++ b/src/components/Dialogs/TimetableModal.jsx
@@ -1,13 +1,7 @@
 import React from 'react'
 import { getSubjectName } from 'src/format/subjectName'
 
-import MuiBreadcrumbs from 'cozy-ui/transpiled/react/Breadcrumbs'
-import {
-  DialogBackButton,
-  DialogCloseButton,
-  useCozyDialog
-} from 'cozy-ui/transpiled/react/CozyDialogs'
-import Dialog, { DialogTitle } from 'cozy-ui/transpiled/react/Dialog'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Divider from 'cozy-ui/transpiled/react/Divider'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import InfoIcon from 'cozy-ui/transpiled/react/Icons/Info'
@@ -26,19 +20,8 @@ import PeopleIcon from 'cozy-ui/transpiled/react/Icons/People'
 
 export const TimetableModal = ({ course, closeModalAction }) => {
   const { isMobile } = useBreakpoints()
-  const { dialogProps, dialogTitleProps } = useCozyDialog({
-    size: 'medium',
-    classes: {
-      paper: 'my-class'
-    },
-    open,
-    onClose: closeModalAction,
-    disableEnforceFocus: true
-  })
 
   const { t } = useI18n()
-
-  console.log(course)
 
   const Time = [
     {
@@ -79,54 +62,56 @@ export const TimetableModal = ({ course, closeModalAction }) => {
   ]
 
   return (
-    <Dialog {...dialogProps}>
-      {!isMobile && <DialogCloseButton onClick={closeModalAction} />}
+    <Dialog
+      open
+      onClose={() => closeModalAction()}
+      disableGutters
 
-      <DialogTitle {...dialogTitleProps}>
-        {isMobile ? <DialogBackButton onClick={closeModalAction} /> : null}
+      title={
+          <div>
+            <Typography variant="h5">
+              {getSubjectName(course.subject).pretty}
+            </Typography>
+            <Typography variant="subtitle2" color="textSecondary">
+              {new Date(course.start).toLocaleDateString('default', {
+                weekday: 'long',
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric'
+              })}
+            </Typography>
+          </div>
+      }
 
+      content={
         <div>
-          <Typography variant="h5">
-            {getSubjectName(course.subject).pretty}
-          </Typography>
-          <Typography variant="subtitle2" color="textSecondary">
-            {new Date(course.start).toLocaleDateString('default', {
-              weekday: 'long',
-              year: 'numeric',
-              month: 'long',
-              day: 'numeric'
-            })}
-          </Typography>
+          <List>
+            <ListSubheader>{t('Timetable.duration')}</ListSubheader>
+
+            {Time.map((info, index) => (
+              <ListItem key={index}>
+                <ListItemIcon>
+                  {info.icon && <Icon icon={info.icon} />}
+                </ListItemIcon>
+                <ListItemText primary={info.title} secondary={info.subtitle} />
+              </ListItem>
+            ))}
+          </List>
+
+          <List>
+            <ListSubheader>{t('Timetable.informations')}</ListSubheader>
+
+            {Informations.map((info, index) => (
+              <ListItem key={index}>
+                <ListItemIcon>
+                  {info.icon && <Icon icon={info.icon} />}
+                </ListItemIcon>
+                <ListItemText primary={info.title} secondary={info.subtitle} />
+              </ListItem>
+            ))}
+          </List>
         </div>
-      </DialogTitle>
-
-      <Divider />
-
-      <List>
-        <ListSubheader>{t('Timetable.duration')}</ListSubheader>
-
-        {Time.map((info, index) => (
-          <ListItem key={index}>
-            <ListItemIcon>
-              {info.icon && <Icon icon={info.icon} />}
-            </ListItemIcon>
-            <ListItemText primary={info.title} secondary={info.subtitle} />
-          </ListItem>
-        ))}
-      </List>
-
-      <List>
-        <ListSubheader>{t('Timetable.informations')}</ListSubheader>
-
-        {Informations.map((info, index) => (
-          <ListItem key={index}>
-            <ListItemIcon>
-              {info.icon && <Icon icon={info.icon} />}
-            </ListItemIcon>
-            <ListItemText primary={info.title} secondary={info.subtitle} />
-          </ListItem>
-        ))}
-      </List>
-    </Dialog>
+      }
+    />
   )
 }

--- a/src/components/Views/GradesView.jsx
+++ b/src/components/Views/GradesView.jsx
@@ -24,6 +24,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { GradeModal } from '../Dialogs/GradesModal'
+import { Outlet, useNavigate } from 'react-router-dom'
 
 const makeStyle = () => ({
   cozyGradeChip: {
@@ -36,6 +37,7 @@ export const GradesView = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const style = makeStyle(isMobile)
+  const navigate = useNavigate()
 
   const gradesQuery = buildGradesQuery()
   const { data: subjects, fetchStatus } = useQuery(
@@ -88,9 +90,6 @@ export const GradesView = () => {
     setSelectedYear(years[0])
   }
 
-  const [openedGrade, setOpenedGrade] = useState(null)
-  const [openedGradeSubject, setOpenedGradeSubject] = useState(null)
-
   const [periodMenuOpen, setPeriodMenuOpen] = useState(false)
   const [yearMenuOpen, setYearMenuOpen] = useState(false)
 
@@ -118,16 +117,7 @@ export const GradesView = () => {
 
   return (
     <>
-      {openedGrade && (
-        <GradeModal
-          grade={openedGrade}
-          subject={openedGradeSubject}
-          closeModalAction={() => {
-            setOpenedGrade(null)
-            setOpenedGradeSubject(null)
-          }}
-        />
-      )}
+      <Outlet />
 
       {isMobile && (
         <>
@@ -277,8 +267,7 @@ export const GradesView = () => {
                   <ListItem
                     button
                     onClick={() => {
-                      setOpenedGrade(grade)
-                      setOpenedGradeSubject(subject)
+                      navigate(`/grades/grade/${subject._id}/${grade.id}`)
                     }}
                   >
                     <ListItemIcon>

--- a/src/components/Views/TimetableView.jsx
+++ b/src/components/Views/TimetableView.jsx
@@ -24,6 +24,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/providers/Breakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/providers/I18n'
 
 import { TimetableModal } from '../Dialogs/TimetableModal'
+import { Outlet, useNavigate } from 'react-router-dom'
 
 const makeStyle = isMobile => ({
   header: {
@@ -41,6 +42,7 @@ export const TimetableView = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const style = makeStyle(isMobile)
+  const navigate = useNavigate()
 
   const [startDate, setStartDate] = useState(new Date('2024-03-01'))
   startDate.setDate(startDate.getDate() - (startDate.getDay() - 1))
@@ -94,18 +96,9 @@ export const TimetableView = () => {
     ]
   }, [])
 
-  const [openedCourse, setOpenedCourse] = useState(null)
-
   return (
     <>
-      {openedCourse && (
-        <TimetableModal
-          course={openedCourse}
-          closeModalAction={() => {
-            setOpenedCourse(null)
-          }}
-        />
-      )}
+      <Outlet />
 
       <div>
         {!isMobile ? (
@@ -196,7 +189,7 @@ export const TimetableView = () => {
                       key={course._id}
                       button
                       onClick={() => {
-                        setOpenedCourse(course)
+                        navigate(`/timetable/course/${course._id}`)
                       }}
                     >
                       <div

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -20,6 +20,19 @@ export const buildTimetableQuery = (start, end) => ({
   }
 })
 
+export const buildTimetableItemQuery = id => ({
+  definition: () =>
+    Q('io.cozy.calendar.event')
+      .where({
+        _id: id
+      })
+      .indexFields(['_id']),
+  options: {
+    as: 'io.cozy.calendar.event.item/' + id,
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
 export const buildHomeworkQuery = () => ({
   definition: () =>
     Q('io.cozy.calendar.todos')
@@ -43,6 +56,19 @@ export const buildGradesQuery = period => ({
       .indexFields(['title']),
   options: {
     as: 'io.cozy.timeseries.grades',
+    fetchPolicy: defaultFetchPolicy
+  }
+})
+
+export const buildGradeItemQuery = id => ({
+  definition: () =>
+    Q('io.cozy.timeseries.grades')
+      .where({
+        _id : id
+      })
+      .indexFields(['_id']),
+  options: {
+    as: 'io.cozy.timeseries.grades.item/' + id,
     fetchPolicy: defaultFetchPolicy
   }
 })


### PR DESCRIPTION
## Change
Instead of adding dialogs to the current view, they now have their own route with an ID passed to fetch data, such as `/timetable/course/:id` for better integration and compatibility.