### PR TITLE
[PRD-478] fix: Month change

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "cozy-logger": "^1.10.4",
     "cozy-minilog": "^3.3.1",
     "cozy-ui": "^109.1.1",
+    "date-fns": "2.29.3",
     "lodash": "4.17.21",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
In some cases, the app was crashing on month change. We refacto the code to make it simpler and avoid race-conditions.



```
### ✨ Features

*

### 🐛 Bug Fixes

* Month change was sometimes crashing

### 🔧 Tech

*
```
