### PR TITLE
fix: Links not redirecting on flagship app on Android

### DIFF
--- a/src/components/Views/EmptyDataView.jsx
+++ b/src/components/Views/EmptyDataView.jsx
@@ -42,8 +42,9 @@ export const EmptyDataView = () => {
           }}
         >
           <AppLinker app={{ slug: 'pronote' }} href={pronoteKonnectorUrl}>
-            {({ href }) => (
+            {({ onClick, href }) => (
               <Button
+                onClick={onClick}
                 variant="secondary"
                 label={t('Layout.importFromButton') + ' Pronote'}
                 startIcon={<img src={PronoteIcon} alt="Pronote" />}
@@ -54,8 +55,9 @@ export const EmptyDataView = () => {
           </AppLinker>
 
           <AppLinker app={{ slug: 'store' }} href={storeEducationUrl}>
-            {({ href }) => (
+            {({ onClick, href }) => (
               <Button
+                onClick={onClick}
                 variant="ghost"
                 label={t('Layout.exploreServices')}
                 style={{ width: '100%' }}


### PR DESCRIPTION
We need to add the onClick prop to make the button work on flagship app.

I will create an issue to investigate the problem on flagship app. It should work without the onClick.

```
### ✨ Features

*

### 🐛 Bug Fixes

* Links not redirecting on flagship app on Android

### 🔧 Tech

*
```
